### PR TITLE
Appki

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -209,6 +209,7 @@ public class FileRecords extends AbstractRecords implements Closeable {
      */
     public void renameTo(File f) throws IOException {
         try {
+            channel.close(); 
             Utils.atomicMoveWithFallback(file.toPath(), f.toPath());
         } finally {
             this.file = f;

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
@@ -33,6 +33,7 @@ import javax.net.ssl.SSLEngineResult;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.TrustManagerFactory;
+
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -74,6 +75,7 @@ public class SslFactory implements Reconfigurable {
     private boolean needClientAuth;
     private boolean wantClientAuth;
 	private String appkiProvider;
+	
 
     public SslFactory(Mode mode) {
         this(mode, null, false);
@@ -318,15 +320,17 @@ public class SslFactory implements Reconfigurable {
          *   using the specified configs (e.g. if the password or keystore type is invalid)
          */
         KeyStore load() {
-            try (FileInputStream in = new FileInputStream(path)) {
+        	FileInputStream in = null;
+        	try {
                 KeyStore ks = KeyStore.getInstance(type);
-				if(type.equalsIgnoreCase("Windows-MY")){
+                if(type.equalsIgnoreCase("Windows-MY")){
                     ks.load(null, null);
                 }else{
-					// If a password is not set access to the truststore is still available, but integrity checking is disabled.
-					char[] passwordChars = password != null ? password.value().toCharArray() : null;
-					ks.load(in, passwordChars);
-				}
+                	in = new FileInputStream(path);
+                	// If a password is not set access to the truststore is still available, but integrity checking is disabled.
+                	char[] passwordChars = password != null ? password.value().toCharArray() : null;
+                	ks.load(in, passwordChars);
+                }
                 return ks;
             } catch (GeneralSecurityException | IOException e) {
                 throw new KafkaException("Failed to load SSL keystore " + path + " of type " + type, e);

--- a/core/src/main/scala/kafka/log/AbstractIndex.scala
+++ b/core/src/main/scala/kafka/log/AbstractIndex.scala
@@ -143,7 +143,10 @@ abstract class AbstractIndex[K, V](@volatile var file: File, val baseOffset: Lon
    * @throws IOException if rename fails
    */
   def renameTo(f: File) {
-    try Utils.atomicMoveWithFallback(file.toPath, f.toPath)
+    try{ 
+      closeHandler()
+      Utils.atomicMoveWithFallback(file.toPath, f.toPath)
+    } 
     finally file = f
   }
 
@@ -237,8 +240,10 @@ abstract class AbstractIndex[K, V](@volatile var file: File, val baseOffset: Lon
    * Forcefully free the buffer's mmap.
    */
   protected[log] def forceUnmap() {
-    try MappedByteBuffers.unmap(file.getAbsolutePath, mmap)
-    finally mmap = null // Accessing unmapped mmap crashes JVM by SEGV so we null it out to be safe
+    if(mmap != null){ 
+      try MappedByteBuffers.unmap(file.getAbsolutePath, mmap) 
+      finally mmap = null // Accessing unmapped mmap crashes JVM by SEGV so we null it out to be safe 
+    } 
   }
 
   /**

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -576,6 +576,7 @@ class Log(@volatile var dir: File,
     lock synchronized {
       maybeHandleIOException(s"Error while renaming dir for $topicPartition in log dir ${dir.getParent}") {
         val renamedDir = new File(dir.getParent, name)
+        closeHandlers()
         Utils.atomicMoveWithFallback(dir.toPath, renamedDir.toPath)
         if (renamedDir != dir) {
           dir = renamedDir

--- a/core/src/main/scala/kafka/log/TransactionIndex.scala
+++ b/core/src/main/scala/kafka/log/TransactionIndex.scala
@@ -103,8 +103,10 @@ class TransactionIndex(val startOffset: Long, @volatile var file: File) extends 
 
   def renameTo(f: File): Unit = {
     try {
-      if (file.exists)
+      if (file.exists) {
+        channel.close()
         Utils.atomicMoveWithFallback(file.toPath, f.toPath)
+      }
     } finally file = f
   }
 


### PR DESCRIPTION
Merge fixes:
1.	https://issues.apache.org/jira/browse/KAFKA-6983
2.	Accessing index memory mapped file that has already closed.

Fix bug when enabling APPKI in kafka1.1.0


