### PR TITLE
Code review revision and fixing bug caused by .cleaned file not closed when disk having no space

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -47,7 +47,7 @@ public class FileRecords extends AbstractRecords implements Closeable {
 
     // mutable state
     private final AtomicInteger size;
-    private FileChannel channel;
+    private volatile FileChannel channel;
     private volatile File file;
     private final String DeletedFileSuffix = ".deleted";
 

--- a/core/src/main/scala/kafka/log/AbstractIndex.scala
+++ b/core/src/main/scala/kafka/log/AbstractIndex.scala
@@ -164,7 +164,7 @@ abstract class AbstractIndex[K, V](@volatile var file: File, val baseOffset: Lon
         if(!f.getName.endsWith(Log.DeletedFileSuffix)) {
           openHandler(new java.io.File(f.toPath.toString))
         } else {
-          logger.info("Handler to deleted file will NOT be reopened.");
+          logger.debug("Handler to deleted file will NOT be reopened.");
         }
       } else {
         Utils.atomicMoveWithFallback(file.toPath, f.toPath)

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -569,17 +569,44 @@ object LogSegment {
   def open(dir: File, baseOffset: Long, config: LogConfig, time: Time, fileAlreadyExists: Boolean = false,
            initFileSize: Int = 0, preallocate: Boolean = false, fileSuffix: String = ""): LogSegment = {
     val maxIndexSize = config.maxIndexSize
-    new LogSegment(
-      FileRecords.open(Log.logFile(dir, baseOffset, fileSuffix), fileAlreadyExists, initFileSize, preallocate),
-      new OffsetIndex(Log.offsetIndexFile(dir, baseOffset, fileSuffix), baseOffset = baseOffset, maxIndexSize = maxIndexSize),
-      new TimeIndex(Log.timeIndexFile(dir, baseOffset, fileSuffix), baseOffset = baseOffset, maxIndexSize = maxIndexSize),
-      new TransactionIndex(baseOffset, Log.transactionIndexFile(dir, baseOffset, fileSuffix)),
-      baseOffset,
-      indexIntervalBytes = config.indexInterval,
-      rollJitterMs = config.randomSegmentJitter,
-      maxSegmentMs = config.segmentMs,
-      maxSegmentBytes = config.segmentSize,
-      time)
+    var log: FileRecords = null
+    var offsetIdx: OffsetIndex = null
+    var timeIdx: TimeIndex = null
+    var txnIdx: TransactionIndex = null
+    try{
+      log = FileRecords.open(Log.logFile(dir, baseOffset, fileSuffix), fileAlreadyExists, initFileSize, preallocate)
+      offsetIdx = new OffsetIndex(Log.offsetIndexFile(dir, baseOffset, fileSuffix), baseOffset = baseOffset, maxIndexSize = maxIndexSize)
+      timeIdx = new TimeIndex(Log.timeIndexFile(dir, baseOffset, fileSuffix), baseOffset = baseOffset, maxIndexSize = maxIndexSize)
+      txnIdx = new TransactionIndex(baseOffset, Log.transactionIndexFile(dir, baseOffset, fileSuffix))
+      new LogSegment(
+        log,
+        offsetIdx,
+        timeIdx,
+        txnIdx,
+        baseOffset,
+        indexIntervalBytes = config.indexInterval,
+        rollJitterMs = config.randomSegmentJitter,
+        maxSegmentMs = config.segmentMs,
+        maxSegmentBytes = config.segmentSize,
+        time)
+    }
+    catch {
+      case ex: IOException => {
+        if(null != log){
+          log.close()
+        }
+        if(null != offsetIdx){
+          offsetIdx.close()
+        }
+        if(null != timeIdx){
+          timeIdx.close()
+        }
+        if(null != txnIdx){
+          txnIdx.close()
+        }
+        throw ex
+      }
+    }
   }
 
 }

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -593,16 +593,16 @@ object LogSegment {
     catch {
       case ex: IOException => {
         if(null != log){
-          log.close()
+          log.deleteIfExists()
         }
         if(null != offsetIdx){
-          offsetIdx.close()
+          offsetIdx.deleteIfExists()
         }
         if(null != timeIdx){
-          timeIdx.close()
+          timeIdx.deleteIfExists()
         }
         if(null != txnIdx){
-          txnIdx.close()
+          txnIdx.deleteIfExists()
         }
         throw ex
       }

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -591,18 +591,18 @@ object LogSegment {
         time)
     }
     catch {
-      case ex: IOException => {
-        if(null != log){
-          log.deleteIfExists()
+      case ex: Throwable=> {
+        if(fileAlreadyExists) {
+          if(null != log) log.close()
+          if(null != offsetIdx) offsetIdx.close()
+          if(null != timeIdx) timeIdx.close()
+          if(null != txnIdx) txnIdx.close()
         }
-        if(null != offsetIdx){
-          offsetIdx.deleteIfExists()
-        }
-        if(null != timeIdx){
-          timeIdx.deleteIfExists()
-        }
-        if(null != txnIdx){
-          txnIdx.deleteIfExists()
+        else {
+          if(null != log) log.deleteIfExists()
+          if(null != offsetIdx) offsetIdx.deleteIfExists()
+          if(null != timeIdx) timeIdx.deleteIfExists()
+          if(null != txnIdx) txnIdx.deleteIfExists()
         }
         throw ex
       }


### PR DESCRIPTION
- Revising the code based on Code Review for Pull Request 16: Channel of FileRecords needs to be volatile. 

- Fixing a bug found in baking test: log cleaner fails to delete .deleted file because the file is opened by Kafka broker. The root cause of this is:  when creating a new Log Segment, different files (log, time index, transaction index etc.) are not created/deleted atomically, which means if a file is failed to create, the other files are still created/opened and file handles are not closed. This will prevent these files being deleted/renamed, since they're owned by the Kafka process.