### PR TITLE
Racing condition causing failed to delete snapshot.

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -314,7 +314,7 @@ class Log(@volatile var dir: File,
   }
 
   // This method does not need to convert IOException to KafkaStorageException because it is only called before all logs are loaded
-  private def loadSegmentFiles(): Unit = {
+  private def loadSegmentFiles(swapFiles: Set[File]): Unit = {
     // load segments in ascending order because transactional data from one segment may depend on the
     // segments that come before it
     for (file <- dir.listFiles.sortBy(_.getName) if file.isFile) {
@@ -326,7 +326,7 @@ class Log(@volatile var dir: File,
           warn(s"Found an orphaned index file ${file.getAbsolutePath}, with no corresponding log file.")
           Files.deleteIfExists(file.toPath)
         }
-      } else if (isLogFile(file)) {
+      } else if (isLogFile(file) && !swapFiles.contains(new File(file.toPath.toString + SwapFileSuffix))) {
         // if it's a log file, load the corresponding log segment
         val baseOffset = offsetFromFile(file)
         val timeIndexFileNewlyCreated = !Log.timeIndexFile(dir, baseOffset).exists()
@@ -400,7 +400,7 @@ class Log(@volatile var dir: File,
     val swapFiles = removeTempFilesAndCollectSwapFiles()
 
     // now do a second pass and load all the log and index files
-    loadSegmentFiles()
+    loadSegmentFiles(swapFiles)
 
     // Finally, complete any interrupted swap operations. To be crash-safe,
     // log files that are replaced by the swap segment should be renamed to .deleted

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -578,7 +578,7 @@ class LogManager(logDirs: Seq[File],
       } catch {
         case e: IOException =>
           logDirFailureChannel.maybeAddOfflineLogDir(dir.getAbsolutePath, s"Disk error while writing to recovery point " +
-            s"file in directory $dir", e)
+            s"file in directory $dir, error message: ${e.getMessage}", e)
       }
     }
   }

--- a/core/src/main/scala/kafka/log/ProducerStateManager.scala
+++ b/core/src/main/scala/kafka/log/ProducerStateManager.scala
@@ -455,10 +455,9 @@ object ProducerStateManager extends Logging {
   private def deleteSnapshotFiles(dir: File, predicate: Long => Boolean = _ => true) {
     listSnapshotFiles(dir).filter(file => predicate(offsetFromFile(file))).foreach { file =>
       val sleepTimeInMs = Thread.currentThread().getId % 107
-      try{
+      try {
         Files.deleteIfExists(file.toPath)
-      }
-      catch {
+      } catch {
         case e: IOException => {
           // Under multi-threading condition, each thread will get IOException if the threads are deleting the file simultaneously.
           // This retry seems be redundant, even though the first deleteIfExists() above throw IOException, the file still gets deleted.

--- a/core/src/main/scala/kafka/log/ProducerStateManager.scala
+++ b/core/src/main/scala/kafka/log/ProducerStateManager.scala
@@ -459,11 +459,17 @@ object ProducerStateManager extends Logging {
   private def deleteSnapshotFiles(dir: File, predicate: Long => Boolean = _ => true) {
     listSnapshotFiles(dir).filter(file => predicate(offsetFromFile(file))).foreach { file =>
       try{
+        info("In deleteSnapshotsBefore, trying to delete the snapshot file. It may throw IOException if two threads are deleting exactly the same file simultaneously.")
+
         Files.deleteIfExists(file.toPath)
       }
       catch {
         case e: IOException => {
-          warn(s"In deleteSnapshotFiles(), Exception happened to deleteIfExists when deleting snapshot file ${file}, error: ${e.getMessage}. Retrying. Sleep before deleteIfExists, thread Id: ${Thread.currentThread().getId}")
+          // Under multi-threading condition, each thread will get IOException if the threads are deleting the file simultaneously.
+          // This retry seems be redundant, even though the first deleteIfExists() above throw IOException, the file still gets deleted.
+          // But to make sure the snapshot will get deleted successfully, we're forcing each thread to sleep with different amount of time before the retry.
+
+          warn(s"In deleteSnapshotFiles(), Exception happened to deleteIfExists when deleting snapshot file ${file.toPath}, error: ${e.getMessage}. Retrying. Sleep before deleteIfExists, thread Id: ${Thread.currentThread().getId}")
           Thread.sleep(Thread.currentThread().getId % 107)
           Files.deleteIfExists(file.toPath)
         }

--- a/core/src/main/scala/kafka/log/ProducerStateManager.scala
+++ b/core/src/main/scala/kafka/log/ProducerStateManager.scala
@@ -20,7 +20,6 @@ import java.io._
 import java.nio.ByteBuffer
 import java.nio.file.Files
 
-import com.typesafe.scalalogging.Logger
 import kafka.common.KafkaException
 import kafka.log.Log.offsetFromFile
 import kafka.server.LogOffsetMetadata
@@ -30,12 +29,9 @@ import org.apache.kafka.common.errors._
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.protocol.types._
 import org.apache.kafka.common.record.{ControlRecordType, EndTransactionMarker, RecordBatch}
-import org.apache.kafka.common.utils.{ByteUtils, Crc32C}
-import org.slf4j.LoggerFactory
-
+import org.apache.kafka.common.utils.{ByteUtils, Crc32C, Utils}
 import scala.collection.mutable.ListBuffer
 import scala.collection.{immutable, mutable}
-import scala.util.Random
 
 class CorruptSnapshotException(msg: String) extends KafkaException(msg)
 
@@ -458,9 +454,8 @@ object ProducerStateManager extends Logging {
 
   private def deleteSnapshotFiles(dir: File, predicate: Long => Boolean = _ => true) {
     listSnapshotFiles(dir).filter(file => predicate(offsetFromFile(file))).foreach { file =>
+      val sleepTimeInMs = Thread.currentThread().getId % 107
       try{
-        info("In deleteSnapshotsBefore, trying to delete the snapshot file. It may throw IOException if two threads are deleting exactly the same file simultaneously.")
-
         Files.deleteIfExists(file.toPath)
       }
       catch {
@@ -469,8 +464,8 @@ object ProducerStateManager extends Logging {
           // This retry seems be redundant, even though the first deleteIfExists() above throw IOException, the file still gets deleted.
           // But to make sure the snapshot will get deleted successfully, we're forcing each thread to sleep with different amount of time before the retry.
 
-          warn(s"In deleteSnapshotFiles(), Exception happened to deleteIfExists when deleting snapshot file ${file.toPath}, error: ${e.getMessage}. Retrying. Sleep before deleteIfExists, thread Id: ${Thread.currentThread().getId}")
-          Thread.sleep(Thread.currentThread().getId % 107)
+          warn(s"In deleteSnapshotFiles, Exception happened to deleteIfExists when deleting snapshot file ${file.toPath}, error: ${e.getMessage}. Retrying. Sleep ${sleepTimeInMs} ms before deleteIfExists, thread Id: ${Thread.currentThread().getId}")
+          Utils.sleep(sleepTimeInMs)
           Files.deleteIfExists(file.toPath)
         }
       }


### PR DESCRIPTION
This fixes a bug in open source Kafka: https://issues.apache.org/jira/browse/KAFKA-8099 

The root cause of this, if the log compaction is interrupted, the .log and .swap files will coexist. When Kafka restarts, it will firstly load the .log file before swapping in the .swap file, and will get Access Denied Exception because the .log file has been opened. 

If the .log file is accompanied with a .swap file, eventually the .swap will be used to recovered the log data. So loading the .log file is completely unnecessary. This is how this fix works.