### PR TITLE
changing logging level from info to debug.

### DIFF
--- a/azpubsub/contextvalidator/src/main/scala/kafka/security/auth/AzPubSubAclAuthorizer.scala
+++ b/azpubsub/contextvalidator/src/main/scala/kafka/security/auth/AzPubSubAclAuthorizer.scala
@@ -232,7 +232,7 @@ class AzPubSubAclAuthorizer extends Authorizer with KafkaMetricsGroup {
           val allBrokers = zkClient.getAllBrokersInCluster
           allBrokers.foreach(b => b.endPoints.foreach(e => {
             brokerHosts += InetAddress.getByName(e.host).getHostAddress
-            info(s"Kafka broker host : ${e.host}")
+            debug(s"Kafka broker host : ${e.host}")
           }))
         }
 


### PR DESCRIPTION
- When any of the brokers is using physical address, and the broker is accessing other brokers, other brokers will keep checking if this broker using physical ip is from the same Kafka cluster. This will generate huge number of logging entries. Refactoring it to debug instead of info. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
