### PR TITLE
Increase the zk session timeout values for reassign command

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -915,6 +915,8 @@ project(':core') {
     from(project(':connect:file').configurations.runtime) { into("libs/") }
     from(project(':connect:basic-auth-extension').jar) { into("libs/") }
     from(project(':connect:basic-auth-extension').configurations.runtime) { into("libs/") }
+    from(project(':connect:mirror').jar) { into("libs/") }
+    from(project(':connect:mirror').configurations.runtime) { into("libs/") }
     from(project(':streams').jar) { into("libs/") }
     from(project(':streams').configurations.runtime) { into("libs/") }
     from(project(':streams:streams-scala').jar) { into("libs/") }

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -52,7 +52,7 @@ object ReassignPartitionsCommand extends Logging {
     val opts = validateAndParseArgs(args)
     val zkConnect = opts.options.valueOf(opts.zkConnectOpt)
     val time = Time.SYSTEM
-    val zkClient = KafkaZkClient(zkConnect, JaasUtils.isZkSecurityEnabled, 30000, 30000, Int.MaxValue, time)
+    val zkClient = KafkaZkClient(zkConnect, JaasUtils.isZkSecurityEnabled, 180000, 180000, Int.MaxValue, time)
 
     val adminClientOpt = createAdminClient(opts)
 


### PR DESCRIPTION
*Reassign command consistently gets timeout exception such as below because of a hardcoded 30sec timeout interval in zk client of reassign command. Not sure if this is a regression with the latest release of ZK, but increasing the ZK session timeout here and we can control the external timeout using zk timeout flag if necessary.*


[2020-12-16 17:18:48,066] INFO EventThread shut down for session: 0xd600050c5d06aab0 (org.apache.zookeeper.ClientCnxn)
Exception in thread "main" kafka.zookeeper.ZooKeeperClientTimeoutException: Timed out waiting for connection while in state: CONNECTING
        at kafka.zookeeper.ZooKeeperClient.$anonfun$waitUntilConnected$3(ZooKeeperClient.scala:259)
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
        at kafka.utils.CoreUtils$.inLock(CoreUtils.scala:269)
        at kafka.zookeeper.ZooKeeperClient.waitUntilConnected(ZooKeeperClient.scala:255)
        at kafka.zookeeper.ZooKeeperClient.<init>(ZooKeeperClient.scala:113)
        at kafka.zk.KafkaZkClient$.apply(KafkaZkClient.scala:1858)
        at kafka.admin.ReassignPartitionsCommand$.main(ReassignPartitionsCommand.scala:55)
        at kafka.admin.ReassignPartitionsCommand.main(ReassignPartitionsCommand.scala)
[2020-12-16 17:18:48,097] TRACE SendThread exited loop for session: 0xd600050c5d06aab0 (org.apache.zookeeper.ClientCnxn)





### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
