### PR TITLE
[AzPubSub] Cache certificate identity in SSL session

### DIFF
--- a/azpubsub/src/main/java/com/microsoft/azpubsub/security/authenticator/AzPubSubPrincipalBuilder.java
+++ b/azpubsub/src/main/java/com/microsoft/azpubsub/security/authenticator/AzPubSubPrincipalBuilder.java
@@ -68,7 +68,13 @@ public class AzPubSubPrincipalBuilder extends DefaultKafkaPrincipalBuilder imple
 
         if (context instanceof SslAuthenticationContext) {
             SSLSession sslSession = ((SslAuthenticationContext) context).session();
-            CertificateIdentity identity = this.certificateIdentifier.getIdentity(sslSession);
+            CertificateIdentity identity;
+            if (sslSession.getValue("CertificateIdentity") == null) {
+                identity = this.certificateIdentifier.getIdentity(sslSession);
+                sslSession.putValue("CertificateIdentity", identity);
+            } else {
+                identity = (CertificateIdentity) sslSession.getValue("CertificateIdentity");
+            }
             return new AzPubSubPrincipal(
                     AzPubSubPrincipal.USER_TYPE,
                     identity.principalName(),


### PR DESCRIPTION
To validate certificate identity, we are calling APPKI for every request. Cache certificate identity so it can be re-used after SSl session is created